### PR TITLE
Refactor map init into MapManager

### DIFF
--- a/src/components/Map/MapContainer.ts
+++ b/src/components/Map/MapContainer.ts
@@ -1,0 +1,34 @@
+export interface MapContainerProps {
+  /** Parent element where the map will be appended */
+  parent: HTMLElement;
+  /** Optional CSS class */
+  className?: string;
+}
+
+/**
+ * Lightweight DOM container for MapGL instance
+ */
+export class MapContainer {
+  private element: HTMLElement;
+
+  constructor(props: MapContainerProps) {
+    this.element = document.createElement('div');
+    this.element.className = props.className || 'dashboard-map';
+    this.element.style.cssText = `
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 375px;
+      max-width: 100%;
+      height: 100%;
+      z-index: 1;
+    `;
+    props.parent.appendChild(this.element);
+  }
+
+  /** Return underlying DOM element */
+  getElement(): HTMLElement {
+    return this.element;
+  }
+}
+

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -1,0 +1,2 @@
+export { MapGLComponent, MapGLComponentFactory } from './MapGLComponent';
+export { MapContainer, type MapContainerProps } from './MapContainer';

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { ScreenType } from './types/navigation';
 import { BottomsheetState, BottomsheetConfig } from './types/bottomsheet';
 import { SearchFlowManager } from './services/SearchFlowManager';
 import { BottomsheetManager } from './services/BottomsheetManager';
-import { MapSyncService } from './services/MapSyncService';
+import { MapSyncService, MapManager } from './services';
 import { DashboardScreen, DashboardScreenFactory } from './components/Screens/DashboardScreen';
 
 /**
@@ -29,6 +29,7 @@ class App {
   private searchFlowManager?: SearchFlowManager;
   private bottomsheetManager?: BottomsheetManager;
   private mapSyncService?: MapSyncService;
+  private mapManager?: MapManager;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -97,6 +98,11 @@ class App {
 
     // Initialize MapSyncService with dummy ref (will be updated by DashboardScreen)
     this.mapSyncService = new MapSyncService({ current: null });
+
+    // Initialize MapManager with API key from environment
+    this.mapManager = new MapManager({
+      mapApiKey: import.meta.env.VITE_MAPGL_KEY || 'bfa6ee5b-5e88-44f0-b4ad-394e819f26fc'
+    });
   }
 
   /**
@@ -112,7 +118,7 @@ class App {
       this.container,
       this.searchFlowManager,
       this.bottomsheetManager,
-      import.meta.env.VITE_MAPGL_KEY || 'bfa6ee5b-5e88-44f0-b4ad-394e819f26fc'
+      this.mapManager!
     );
 
     // Activate the screen

--- a/src/services/MapManager.ts
+++ b/src/services/MapManager.ts
@@ -1,0 +1,132 @@
+import { MapContainer } from '../components/Map/MapContainer';
+
+export interface MapManagerOptions {
+  /** 2GIS API key */
+  mapApiKey?: string;
+}
+
+/**
+ * Simple manager responsible for creating and keeping reference
+ * to the MapGL instance. Used by screens via dependency injection.
+ */
+export class MapManager {
+  private options: MapManagerOptions;
+  private mapComponent: any;
+
+  constructor(options: MapManagerOptions = {}) {
+    this.options = options;
+  }
+
+  /**
+   * Create map container element and initialize real map.
+   */
+  async createMapContainer(parent: HTMLElement): Promise<MapContainer> {
+    const container = new MapContainer({ parent });
+    try {
+      await this.waitForMapGL();
+      await this.createRealMap(container.getElement());
+    } catch (error) {
+      console.error('Map loading error:', error);
+      this.createFallbackMap(container.getElement());
+    }
+    return container;
+  }
+
+  /**
+   * Wait for MapGL API to be available
+   */
+  private async waitForMapGL(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let attempts = 0;
+      const maxAttempts = 30;
+
+      const checkMapGL = () => {
+        attempts++;
+        if ((window as any).mapgl && (window as any).mapgl.Map) {
+          console.log(`✅ MapGL API v1 загружен (попытка ${attempts})`);
+          resolve((window as any).mapgl);
+        } else if (attempts >= maxAttempts) {
+          reject(new Error('MapGL API v1 не загрузился'));
+        } else {
+          setTimeout(checkMapGL, 200);
+        }
+      };
+      checkMapGL();
+    });
+  }
+
+  /**
+   * Create 2GIS map instance
+   */
+  private async createRealMap(container: HTMLElement): Promise<void> {
+    const mapId = `mapgl-container-${Date.now()}`;
+    container.id = mapId;
+
+    this.mapComponent = new (window as any).mapgl.Map(mapId, {
+      center: [37.620393, 55.75396],
+      zoom: 12,
+      key: this.options.mapApiKey || 'bfa6ee5b-5e88-44f0-b4ad-394e819f26fc'
+    });
+
+    await new Promise<void>((resolve) => {
+      let resolved = false;
+      this.mapComponent.on('styleload', () => {
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      });
+      setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      }, 5000);
+    });
+
+    this.mapComponent.on('click', (event: any) => {
+      // Placeholder for click handling; consumers may subscribe via map instance
+    });
+  }
+
+  /**
+   * Create fallback view when MapGL is unavailable
+   */
+  private createFallbackMap(container: HTMLElement): void {
+    container.innerHTML = `
+      <div style="
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(45deg, #E8F4F8 0%, #D4E8F0 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        color: #666;
+      ">
+        <div class="map-placeholder-icon" style="
+          font-size: 48px;
+          margin-bottom: 16px;
+        ">🗺️</div>
+        <div>Карта недоступна</div>
+        <div style="font-size: 12px; margin-top: 8px;">
+          MapGL API не загрузился
+        </div>
+      </div>
+    `;
+  }
+
+  /** Get map instance */
+  getMapInstance(): any {
+    return this.mapComponent;
+  }
+
+  /** Destroy created map */
+  destroy(): void {
+    if (this.mapComponent) {
+      this.mapComponent.destroy();
+      this.mapComponent = undefined;
+    }
+  }
+}
+

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,4 +6,7 @@ export { BottomsheetScrollManager } from './BottomsheetScrollManager';
 export { SearchFlowManager } from './SearchFlowManager';
 
 // Экспорт сервиса синхронизации карты
-export { MapSyncService, MapSyncServiceFactory } from './MapSyncService'; 
+export { MapSyncService, MapSyncServiceFactory } from './MapSyncService';
+
+// Экспорт менеджера карты
+export { MapManager } from './MapManager';


### PR DESCRIPTION
## Summary
- add `MapManager` service to handle map creation
- add lightweight `MapContainer` component
- inject `MapManager` into `DashboardScreen`
- expose `MapManager` from services and map components from Map index
- wire up `MapManager` in `main.ts`

## Testing
- `npm run type-check`
- `npm run lint:check` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68892ad1d5108330bce5b0188871801e