### PR TITLE
Add TabBar component and integrate with organization screen

### DIFF
--- a/src/components/Organization/TabBar.ts
+++ b/src/components/Organization/TabBar.ts
@@ -1,0 +1,124 @@
+export interface TabItem {
+  label: string;
+  count?: number;
+}
+
+export interface TabBarProps {
+  container: HTMLElement;
+  items: TabItem[];
+  activeIndex?: number;
+  onTabSelect?: (index: number) => void;
+}
+
+export class TabBar {
+  private props: Required<Omit<TabBarProps, 'activeIndex'>> & { activeIndex: number };
+  private element: HTMLElement;
+
+  constructor(props: TabBarProps) {
+    this.props = { activeIndex: 0, ...props } as Required<Omit<TabBarProps, 'activeIndex'>> & { activeIndex: number };
+    this.element = props.container;
+    this.render();
+  }
+
+  private render(): void {
+    this.element.className = 'tab-bar';
+    this.element.style.cssText = `
+      position: relative;
+      background: #FFF;
+      border-bottom: 1px solid rgba(137, 137, 137, 0.15);
+    `;
+
+    const fadeMask = document.createElement('div');
+    fadeMask.style.cssText = `
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      pointer-events: none;
+      background: linear-gradient(90deg, rgba(255,255,255,0.8) 0px, transparent 16px, transparent calc(100% - 16px), rgba(255,255,255,0.8) 100%);
+    `;
+
+    const tabsContainer = document.createElement('div');
+    tabsContainer.className = 'tab-bar-container';
+    tabsContainer.style.cssText = `
+      display: flex;
+      overflow-x: auto;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    `;
+
+    const style = document.createElement('style');
+    style.textContent = '.tab-bar-container::-webkit-scrollbar{display:none;}';
+    document.head.appendChild(style);
+
+    this.props.items.forEach((item, idx) => {
+      const tab = this.createTab(item, idx === this.props.activeIndex, idx);
+      tabsContainer.appendChild(tab);
+    });
+
+    this.element.appendChild(fadeMask);
+    this.element.appendChild(tabsContainer);
+  }
+
+  private createTab(item: TabItem, active: boolean, index: number): HTMLElement {
+    const tab = document.createElement('div');
+    tab.style.cssText = `
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 9px 12px;
+      cursor: pointer;
+      border-bottom: ${active ? '2px solid #1976D2' : '2px solid transparent'};
+      white-space: nowrap;
+      transition: border-color 0.2s ease;
+    `;
+
+    tab.addEventListener('click', () => {
+      this.props.onTabSelect?.(index);
+    });
+
+    const label = document.createElement('span');
+    label.textContent = item.label;
+    label.style.cssText = `
+      color: ${active ? '#1976D2' : '#898989'};
+      font-family: SB Sans Text, -apple-system, Roboto, Helvetica, sans-serif;
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 18px;
+      letter-spacing: -0.28px;
+    `;
+    tab.appendChild(label);
+
+    if (item.count !== undefined) {
+      const counter = document.createElement('div');
+      counter.style.cssText = `
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        padding: 1px 5px 2px 5px;
+        min-width: 19px;
+        height: 18px;
+        border-radius: 12px;
+        background: rgba(20, 20, 20, 0.30);
+      `;
+
+      const counterText = document.createElement('span');
+      counterText.textContent = item.count.toString();
+      counterText.style.cssText = `
+        color: #FFF;
+        font-family: SB Sans Text, -apple-system, Roboto, Helvetica, sans-serif;
+        font-size: 13px;
+        font-weight: 400;
+        line-height: 16px;
+        letter-spacing: -0.234px;
+      `;
+
+      counter.appendChild(counterText);
+      tab.appendChild(counter);
+    }
+
+    return tab;
+  }
+}

--- a/src/components/Organization/index.ts
+++ b/src/components/Organization/index.ts
@@ -1,0 +1,2 @@
+export { TabBar } from './TabBar';
+export type { TabBarProps, TabItem } from './TabBar';

--- a/src/components/Screens/OrganizationScreen.ts
+++ b/src/components/Screens/OrganizationScreen.ts
@@ -1,5 +1,6 @@
 import { Organization, ScreenType } from '../../types';
 import { BottomsheetManager, MapSyncService, SearchFlowManager } from '../../services';
+import { TabBar } from '../Organization';
 
 /**
  * Пропсы для OrganizationScreen
@@ -93,11 +94,7 @@ export class OrganizationScreen {
     const organizationCardTop = this.createOrganizationCardTop();
     bottomsheetContent.appendChild(organizationCardTop);
 
-    // 2. Создаем табы
-    const tabBar = this.createTabBar();
-    bottomsheetContent.appendChild(tabBar);
-
-    // 3. Создаем прокручиваемое содержимое
+    // 2. Создаем прокручиваемое содержимое
     const scrollableContent = document.createElement('div');
     Object.assign(scrollableContent.style, {
       flex: '1',
@@ -560,127 +557,6 @@ export class OrganizationScreen {
     return container;
   }
 
-  /**
-   * Создание панели табов
-   */
-  private createTabBar(): HTMLElement {
-    const tabBar = document.createElement('div');
-    Object.assign(tabBar.style, {
-      position: 'relative',
-      backgroundColor: '#ffffff',
-      borderBottom: '1px solid rgba(137, 137, 137, 0.15)',
-    });
-
-    // Fade mask
-    const fadeMask = document.createElement('div');
-    Object.assign(fadeMask.style, {
-      position: 'absolute',
-      top: '0',
-      left: '0',
-      right: '0',
-      bottom: '0',
-      pointerEvents: 'none',
-      background: 'linear-gradient(90deg, rgba(255,255,255,0.8) 0px, transparent 16px, transparent calc(100% - 16px), rgba(255,255,255,0.8) 100%)',
-    });
-
-    // Табы контейнер
-    const tabsContainer = document.createElement('div');
-    Object.assign(tabsContainer.style, {
-      display: 'flex',
-      overflowX: 'auto',
-      scrollbarWidth: 'none',
-      msOverflowStyle: 'none',
-    });
-
-    // Скрываем scrollbar в webkit
-    const style = document.createElement('style');
-    style.textContent = `
-      .tabs-container::-webkit-scrollbar {
-        display: none;
-      }
-    `;
-    document.head.appendChild(style);
-    tabsContainer.classList.add('tabs-container');
-
-    const tabs = [
-      { name: 'Обзор', active: true, count: null },
-      { name: 'Меню', active: false, count: 213 },
-      { name: 'Фото', active: false, count: 432 },
-      { name: 'Отзывы', active: false, count: 232 },
-      { name: 'Инфо', active: false, count: null },
-      { name: 'Акции', active: false, count: null },
-    ];
-
-    tabs.forEach(tab => {
-      const tabElement = this.createTab(tab.name, tab.active, tab.count);
-      tabsContainer.appendChild(tabElement);
-    });
-
-    tabBar.appendChild(fadeMask);
-    tabBar.appendChild(tabsContainer);
-
-    return tabBar;
-  }
-
-  /**
-   * Создание отдельного таба
-   */
-  private createTab(name: string, active: boolean, count: number | null): HTMLElement {
-    const tab = document.createElement('div');
-    Object.assign(tab.style, {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '4px',
-      padding: '12px 16px',
-      cursor: 'pointer',
-      borderBottom: active ? '2px solid #1976D2' : '2px solid transparent',
-      whiteSpace: 'nowrap',
-      transition: 'border-color 0.2s ease',
-    });
-
-    const label = document.createElement('span');
-    Object.assign(label.style, {
-      color: active ? '#1976D2' : '#898989',
-      fontFamily: 'SB Sans Text, -apple-system, Roboto, Helvetica, sans-serif',
-      fontSize: '14px',
-      fontWeight: '500',
-      lineHeight: '18px',
-      letterSpacing: '-0.28px',
-    });
-    label.textContent = name;
-
-    tab.appendChild(label);
-
-    if (count !== null) {
-      const counter = document.createElement('div');
-      Object.assign(counter.style, {
-        minWidth: '19px',
-        height: '19px',
-        padding: '2px 6px',
-        borderRadius: '10px',
-        backgroundColor: 'rgba(20, 20, 20, 0.06)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      });
-
-      const counterText = document.createElement('span');
-      Object.assign(counterText.style, {
-        color: '#898989',
-        fontFamily: 'SB Sans Text, -apple-system, Roboto, Helvetica, sans-serif',
-        fontSize: '13px',
-        fontWeight: '500',
-        lineHeight: '16px',
-        letterSpacing: '-0.234px',
-      });
-      counterText.textContent = count.toString();
-
-      counter.appendChild(counterText);
-      tab.appendChild(counter);
-    }
-
-    return tab;
-  }
 
   /**
    * Создание основного содержимого
@@ -737,6 +613,21 @@ export class OrganizationScreen {
     // Инфо
     const info = this.createInfoSection();
     container.appendChild(info);
+
+    // Панель табов
+    const tabContainer = document.createElement('div');
+    new TabBar({
+      container: tabContainer,
+      items: [
+        { label: 'Обзор' },
+        { label: 'Меню', count: 213 },
+        { label: 'Фото', count: 432 },
+        { label: 'Отзывы', count: 232 },
+        { label: 'Инфо' },
+        { label: 'Акции' },
+      ],
+    });
+    container.appendChild(tabContainer);
 
     // Нижняя кнопка действия
     const bottomAction = this.createBottomActionBar();


### PR DESCRIPTION
## Summary
- implement `TabBar` component styled from Figma assets
- export new organization components
- use `TabBar` in `OrganizationScreen` and append it before the bottom action bar

## Testing
- `npm run lint:check` *(fails: Definition for rule '@typescript-eslint/prefer-const' was not found)*
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889602fd24883309b578ebf9b18c620