### PR TITLE
Integrate figma templates in organization screen

### DIFF
--- a/src/components/Organization/index.ts
+++ b/src/components/Organization/index.ts
@@ -1,2 +1,3 @@
 export { TabBar } from './TabBar';
 export type { TabBarProps, TabItem } from './TabBar';
+export { createHeaderNotAdvertiser } from './templates';

--- a/src/components/Organization/templates.ts
+++ b/src/components/Organization/templates.ts
@@ -1,0 +1,39 @@
+import headerHtml from '../../../figma_export/org/components/header_not_advertiser/pages/0001.html?raw';
+
+function extractBody(html: string): string {
+  const match = html.match(/<body[^>]*>([\s\S]*?)<\/body>/);
+  return match ? match[1] : html;
+}
+
+const headerBody = extractBody(headerHtml);
+
+export interface HeaderData {
+  name: string;
+  category: string;
+  rating: number;
+  reviews: number;
+  time?: string;
+}
+
+export function createHeaderNotAdvertiser(data: HeaderData): HTMLElement {
+  const template = document.createElement('template');
+  template.innerHTML = headerBody.trim();
+  const element = template.content.firstElementChild as HTMLElement;
+
+  const title = element.querySelector('.inline-element-31');
+  if (title) title.textContent = data.name;
+
+  const subtitle = element.querySelector('.inline-element-36');
+  if (subtitle) subtitle.textContent = data.category;
+
+  const rating = element.querySelector('.inline-element-75');
+  if (rating) rating.textContent = data.rating.toFixed(1);
+
+  const reviews = element.querySelector('.inline-element-78');
+  if (reviews) reviews.textContent = `${data.reviews} оценок`;
+
+  const time = element.querySelector('.inline-element-84');
+  if (time && data.time) time.textContent = data.time;
+
+  return element.cloneNode(true) as HTMLElement;
+}

--- a/src/components/Screens/OrganizationScreen.ts
+++ b/src/components/Screens/OrganizationScreen.ts
@@ -1,6 +1,6 @@
 import { Organization, ScreenType } from '../../types';
 import { BottomsheetManager, MapSyncService, SearchFlowManager } from '../../services';
-import { TabBar } from '../Organization';
+import { TabBar, createHeaderNotAdvertiser } from '../Organization';
 
 /**
  * Пропсы для OrganizationScreen
@@ -58,14 +58,6 @@ export class OrganizationScreen {
    */
   private setupElement(): void {
     this.element.innerHTML = '';
-    Object.assign(this.element.style, {
-      position: 'relative',
-      width: '100%',
-      height: '100%',
-      backgroundColor: '#ffffff',
-      borderRadius: '16px 16px 0 0',
-      overflow: 'hidden',
-    });
 
     if (this.props.className) {
       this.element.className = this.props.className;
@@ -79,16 +71,7 @@ export class OrganizationScreen {
   private createNonAdvertiserLayout(): void {
     // Основной контейнер шторки
     const bottomsheetContent = document.createElement('div');
-    Object.assign(bottomsheetContent.style, {
-      position: 'relative',
-      width: '100%',
-      height: '100%',
-      backgroundColor: '#ffffff',
-      borderRadius: '16px 16px 0 0',
-      overflow: 'hidden',
-      display: 'flex',
-      flexDirection: 'column',
-    });
+    bottomsheetContent.className = 'bottomsheet-content';
 
     // 1. Создаем заголовок организации (Organization card top)
     const organizationCardTop = this.createOrganizationCardTop();
@@ -96,11 +79,7 @@ export class OrganizationScreen {
 
     // 2. Создаем прокручиваемое содержимое
     const scrollableContent = document.createElement('div');
-    Object.assign(scrollableContent.style, {
-      flex: '1',
-      overflowY: 'auto',
-      backgroundColor: '#ffffff',
-    });
+    scrollableContent.className = 'scrollable-content';
 
     // 4. Создаем основное содержимое (Content-non-RD)
     const contentContainer = this.createContentContainer();
@@ -115,101 +94,13 @@ export class OrganizationScreen {
    * Создание заголовка организации (Organization card top)
    */
   private createOrganizationCardTop(): HTMLElement {
-    const cardTop = document.createElement('div');
-    Object.assign(cardTop.style, {
-      backgroundColor: '#ffffff',
-      borderRadius: '16px 16px 0 0',
-      position: 'relative',
+    return createHeaderNotAdvertiser({
+      name: this.props.organization.name,
+      category: this.props.organization.category,
+      rating: this.props.organization.rating || 4.6,
+      reviews: this.props.organization.reviewsCount || 0,
+      time: '3 мин',
     });
-
-    // Drag handle
-    const draggerContainer = document.createElement('div');
-    Object.assign(draggerContainer.style, {
-      display: 'flex',
-      height: '0',
-      paddingBottom: '6px',
-      flexDirection: 'column',
-      justifyContent: 'flex-end',
-      alignItems: 'center',
-      alignSelf: 'stretch',
-      position: 'relative',
-      paddingTop: '16px',
-    });
-
-    const dragger = document.createElement('div');
-    Object.assign(dragger.style, {
-      width: '40px',
-      height: '4px',
-      flexShrink: '0',
-      borderRadius: '6px',
-      background: 'rgba(137, 137, 137, 0.25)',
-      cursor: 'grab',
-    });
-
-    draggerContainer.appendChild(dragger);
-    cardTop.appendChild(draggerContainer);
-
-    // RD контент контейнер
-    const rdContainer = document.createElement('div');
-    Object.assign(rdContainer.style, {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      alignSelf: 'stretch',
-      borderRadius: '16px 16px 0 0',
-      background: '#FFF',
-    });
-
-    // Контент с padding
-    const contentContainer = document.createElement('div');
-    Object.assign(contentContainer.style, {
-      display: 'flex',
-      padding: '0 16px 16px 16px',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      alignSelf: 'stretch',
-    });
-
-    // Верхняя секция с контентом и кнопкой закрытия
-    const topSection = document.createElement('div');
-    Object.assign(topSection.style, {
-      display: 'flex',
-      alignItems: 'flex-start',
-      gap: '8px',
-      alignSelf: 'stretch',
-    });
-
-    // Левая секция с друзьями и заголовком
-    const leftContent = document.createElement('div');
-    Object.assign(leftContent.style, {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      flex: '1 0 0',
-    });
-
-
-
-    // Заголовок карточки
-    const cardHeader = this.createCardHeader();
-    leftContent.appendChild(cardHeader);
-
-    topSection.appendChild(leftContent);
-
-    // Кнопка закрытия
-    const closeButton = this.createCloseButton();
-    topSection.appendChild(closeButton);
-
-    contentContainer.appendChild(topSection);
-
-    // Секция с рейтингом и временем поездки
-    const ratingSection = this.createRatingSection();
-    contentContainer.appendChild(ratingSection);
-
-    rdContainer.appendChild(contentContainer);
-    cardTop.appendChild(rdContainer);
-
-    return cardTop;
   }
 
   /**
@@ -1161,41 +1052,11 @@ export class OrganizationScreen {
    */
   private createBottomActionBar(): HTMLElement {
     const actionBar = document.createElement('div');
-    Object.assign(actionBar.style, {
-      position: 'fixed',
-      bottom: '0',
-      left: '0',
-      right: '0',
-      padding: '16px',
-      backgroundColor: '#ffffff',
-      borderTop: '1px solid rgba(137, 137, 137, 0.15)',
-      zIndex: '100',
-    });
+    actionBar.className = 'bottom-action';
 
     const button = document.createElement('button');
-    Object.assign(button.style, {
-      width: '100%',
-      padding: '16px',
-      backgroundColor: '#1976D2',
-      color: '#ffffff',
-      border: 'none',
-      borderRadius: '12px',
-      fontFamily: 'SB Sans Text, -apple-system, Roboto, Helvetica, sans-serif',
-      fontSize: '16px',
-      fontWeight: '600',
-      lineHeight: '20px',
-      letterSpacing: '-0.24px',
-      cursor: 'pointer',
-      transition: 'background-color 0.2s ease',
-    });
     button.textContent = 'Написать отзыв';
 
-    button.addEventListener('mouseenter', () => {
-      button.style.backgroundColor = '#1565C0';
-    });
-    button.addEventListener('mouseleave', () => {
-      button.style.backgroundColor = '#1976D2';
-    });
 
     actionBar.appendChild(button);
 
@@ -1271,7 +1132,7 @@ export class OrganizationScreen {
   public updateOrganization(organization: Organization): void {
     this.props.organization = organization;
     // Обновляем заголовок и другие элементы
-    const title = this.element.querySelector('span[style*="font-size: 19px"]');
+    const title = this.element.querySelector('.inline-element-31');
     if (title) {
       title.textContent = organization.name;
     }

--- a/src/styles/figma-components.css
+++ b/src/styles/figma-components.css
@@ -1038,3 +1038,87 @@
     letter-spacing: -0.28px;
     padding: 2px 0;
 } 
+/* Organization screen container */
+.organization-screen {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: #FFF;
+    border-radius: 16px 16px 0 0;
+    overflow: hidden;
+}
+
+.organization-screen .bottomsheet-content {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: #FFF;
+    border-radius: 16px 16px 0 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.organization-screen .scrollable-content {
+    flex: 1;
+    overflow-y: auto;
+    background: #FFF;
+}
+
+.organization-screen .card-top {
+    background: #FFF;
+    border-radius: 16px 16px 0 0;
+    position: relative;
+}
+
+.organization-screen .dragger {
+    display: flex;
+    height: 0;
+    padding-top: 16px;
+    padding-bottom: 6px;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    align-self: stretch;
+    position: relative;
+}
+
+.organization-screen .dragger-handle {
+    width: 40px;
+    height: 4px;
+    flex-shrink: 0;
+    border-radius: 6px;
+    background: rgba(137, 137, 137, 0.25);
+    cursor: grab;
+}
+
+.organization-screen .bottom-action {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 16px;
+    background: #FFF;
+    border-top: 1px solid rgba(137, 137, 137, 0.15);
+    z-index: 100;
+}
+
+.organization-screen .bottom-action button {
+    width: 100%;
+    padding: 16px;
+    background: #1976D2;
+    color: #FFF;
+    border: none;
+    border-radius: 12px;
+    font-family: "SB Sans Text", -apple-system, Roboto, Helvetica, sans-serif;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 20px;
+    letter-spacing: -0.24px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+.organization-screen .bottom-action button:hover {
+    background: #1565C0;
+}
+


### PR DESCRIPTION
## Summary
- centralize styles for organization screen in `figma-components.css`
- add helper to load header markup from Figma export
- use Figma header template in `OrganizationScreen`

## Testing
- `npm run type-check`
- `npm run lint:check` *(fails: Definition for rule '@typescript-eslint/prefer-const' was not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68898143044c8330b6f39160dd3a6b91