### PR TITLE
Fix screen change event on history back

### DIFF
--- a/src/services/SearchFlowManager.ts
+++ b/src/services/SearchFlowManager.ts
@@ -124,6 +124,9 @@ export class SearchFlowManager implements ISearchFlowManager {
    */
   goBack(): void {
     if (this.navigationHistory.length > 1) {
+      // Сохраняем экран, с которого уходим
+      const fromScreen = this.currentScreen;
+
       // Убираем текущий экран из истории
       this.navigationHistory.pop();
 
@@ -132,6 +135,9 @@ export class SearchFlowManager implements ISearchFlowManager {
 
       // Переходим без добавления в историю
       this.setCurrentScreen(previousScreen);
+
+      // Вызываем событие смены экрана
+      this.events.onScreenChange?.(fromScreen, previousScreen, this.searchContext);
 
       // Восстанавливаем позицию скролла после короткой задержки
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- fire onScreenChange when navigating backwards

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/prefer-const' was not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889bee1c89c83308fd17ec635add391